### PR TITLE
feat(projects): floating secondary images on project previews

### DIFF
--- a/src/components/projects.astro
+++ b/src/components/projects.astro
@@ -47,7 +47,7 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
 
 <h2 id="projects" class="text-4xl font-bold mt-52">{t("projects.title")}</h2>
 <h3 class="text-lg text-slate-700 mb-8">{t("projects.subtitle")}</h3>
-<ul class="mb-24">
+<ul class="mb-24 pt-6">
   {
     activeProjectsShowcase.map((entry, index) => {
       const img = entry.data.image;
@@ -95,7 +95,7 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
         return <div class={`float-img float-img-${secIndex + 1} hidden md:block`}>{inner}</div>;
       });
       return (
-        <li id={`project-${slug}`} class:list={["group grid lg:grid-cols-2 gap-8 items-center my-24 first:mt-0 last:mb-0 scroll-mt-[90px]", { "opacity-60": entry.data.disabled }]}>
+        <li id={`project-${slug}`} class:list={["group grid lg:grid-cols-2 gap-12 lg:gap-x-20 items-center my-24 first:mt-0 last:mb-0 scroll-mt-[90px]", { "opacity-60": entry.data.disabled }]}>
           <div class="relative lg:group-odd:order-1">
             {floatNodes}
             {entry.data.disabled ? (
@@ -131,23 +131,29 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
     z-index: 0;
     animation: floatY var(--float-dur, 8s) ease-in-out var(--float-delay, 0s) infinite alternate;
   }
+  /* Below lg the layout is stacked: keep side overhangs small so floats
+     never spill off-screen or under the text below */
   .float-img-1 {
-    top: -2rem;
-    left: -2.5rem;
+    top: -2.5rem;
+    left: -1rem;
     width: 58%;
     --float-rot: -5deg;
     --float-dur: 8s;
   }
   .float-img-2 {
     bottom: -2.5rem;
-    right: -2.5rem;
+    right: -1rem;
     width: 52%;
     --float-rot: 4deg;
     --float-dur: 11s;
     --float-delay: -4s;
   }
-  /* Mirror offsets on odd rows (image column on the right) so floats peek outward */
+  /* On lg+ overhang generously on the outer edge only; the edge facing the
+     text column stays modest so floats never sit behind the text */
   @media (min-width: 1024px) {
+    .float-img-1 {
+      left: -2.5rem;
+    }
     li.group:nth-child(odd) .float-img-1 {
       left: auto;
       right: -2.5rem;
@@ -155,7 +161,7 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
     }
     li.group:nth-child(odd) .float-img-2 {
       right: auto;
-      left: -2.5rem;
+      left: -1rem;
       --float-rot: -4deg;
     }
   }

--- a/src/components/projects.astro
+++ b/src/components/projects.astro
@@ -39,6 +39,8 @@ const imagesByName = Object.fromEntries(
 
 const CARD_WIDTHS = [400, 600, 800, 1200];
 const CARD_SIZES = "(min-width: 1024px) 50vw, 100vw";
+const FLOAT_WIDTHS = [300, 500, 700];
+const FLOAT_SIZES = "(min-width: 1024px) 30vw, 60vw";
 
 const slugOf = (id: string) => id.slice(locale.length + 1);
 ---
@@ -73,17 +75,39 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
         const rawSrc = meta ? meta.src : img.src;
         mediaNode = <img class={imgClass} src={rawSrc} alt={img.alt} loading={loading} data-parallax="0.05" />;
       }
+      const floatImgClass = "w-full h-auto object-cover rounded-lg shadow-lg";
+      const floatNodes = entry.data.images.slice(0, 2).map((sec, secIndex) => {
+        const secMeta = imagesByName[sec.src];
+        const secAnimated = /\.gif$/i.test(sec.src);
+        const inner =
+          secMeta && !secAnimated ? (
+            <Image
+              class={floatImgClass}
+              src={secMeta}
+              alt={sec.alt}
+              widths={FLOAT_WIDTHS}
+              sizes={FLOAT_SIZES}
+              loading="lazy"
+            />
+          ) : (
+            <img class={floatImgClass} src={secMeta ? secMeta.src : sec.src} alt={sec.alt} loading="lazy" />
+          );
+        return <div class={`float-img float-img-${secIndex + 1} hidden md:block`}>{inner}</div>;
+      });
       return (
         <li id={`project-${slug}`} class:list={["group grid lg:grid-cols-2 gap-8 items-center my-24 first:mt-0 last:mb-0 scroll-mt-[90px]", { "opacity-60": entry.data.disabled }]}>
-          {entry.data.disabled ? (
-            <div class="watermark-hover lg:group-odd:order-1 block overflow-hidden rounded-lg cursor-not-allowed">
-              {mediaNode}
-            </div>
-          ) : (
-            <a href={projectHref} class="watermark-hover lg:group-odd:order-1 block overflow-hidden rounded-lg" transition:name={heroName}>
-              {mediaNode}
-            </a>
-          )}
+          <div class="relative lg:group-odd:order-1">
+            {floatNodes}
+            {entry.data.disabled ? (
+              <div class="watermark-hover relative z-10 block overflow-hidden rounded-lg cursor-not-allowed">
+                {mediaNode}
+              </div>
+            ) : (
+              <a href={projectHref} class="watermark-hover relative z-10 block overflow-hidden rounded-lg" transition:name={heroName}>
+                {mediaNode}
+              </a>
+            )}
+          </div>
           <div class="lg:group-odd:text-right">
             {entry.data.disabled ? (
               <h3 class="text-3xl font-bold">{entry.data.title}</h3>
@@ -100,3 +124,53 @@ const slugOf = (id: string) => id.slice(locale.length + 1);
     })
   }
 </ul>
+
+<style is:global>
+  .float-img {
+    position: absolute;
+    z-index: 0;
+    animation: floatY var(--float-dur, 8s) ease-in-out var(--float-delay, 0s) infinite alternate;
+  }
+  .float-img-1 {
+    top: -2rem;
+    left: -2.5rem;
+    width: 58%;
+    --float-rot: -5deg;
+    --float-dur: 8s;
+  }
+  .float-img-2 {
+    bottom: -2.5rem;
+    right: -2.5rem;
+    width: 52%;
+    --float-rot: 4deg;
+    --float-dur: 11s;
+    --float-delay: -4s;
+  }
+  /* Mirror offsets on odd rows (image column on the right) so floats peek outward */
+  @media (min-width: 1024px) {
+    li.group:nth-child(odd) .float-img-1 {
+      left: auto;
+      right: -2.5rem;
+      --float-rot: 5deg;
+    }
+    li.group:nth-child(odd) .float-img-2 {
+      right: auto;
+      left: -2.5rem;
+      --float-rot: -4deg;
+    }
+  }
+  @keyframes floatY {
+    from {
+      transform: translateY(-10px) rotate(var(--float-rot, 0deg));
+    }
+    to {
+      transform: translateY(10px) rotate(var(--float-rot, 0deg));
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .float-img {
+      animation: none;
+      transform: rotate(var(--float-rot, 0deg));
+    }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -35,6 +35,16 @@ const portfolioCollection = defineCollection({
       src: z.string(),
       alt: z.string(),
     }),
+    // Up to 2 secondary images floating behind the main one on the home page
+    images: z
+      .array(
+        z.object({
+          src: z.string(),
+          alt: z.string(),
+        }),
+      )
+      .max(2)
+      .default([]),
     ogImage: z.string().optional(),
     technos: z.array(z.string()),
     startDate: z.string().transform((str) => new Date(str)),

--- a/src/content/portfolio/en/je-intervenants.md
+++ b/src/content/portfolio/en/je-intervenants.md
@@ -4,6 +4,9 @@ title: "JE Intervenants"
 snippet: "Platform for Junior ISEP to connect alumni and industry experts with student project teams through a browsable expert directory."
 image:
   { src: "je-intervenants-banner.png", alt: "JE Intervenants platform banner" }
+images:
+  - { src: "je-intervenants-design-thinking.png", alt: "Design thinking workshop board" }
+  - { src: "je-intervenants-notion-crm.png", alt: "Notion CRM for intervenants" }
 technos: ["Design Thinking", "UX Research", "Product Design", "Scrum", "Figma", "Notion", "CI/CD"]
 startDate: "2024-01-01 00:00"
 demo: "https://je-intervenants.juniorisep.com/"

--- a/src/content/portfolio/en/midgard.md
+++ b/src/content/portfolio/en/midgard.md
@@ -4,6 +4,9 @@ title: "Midgard"
 snippet: "Score-based competitive markets on Starknet. Factory Owners stake on game scores, Challengers pay to beat them, Vault Investors provide capital. Built by RuneLabs."
 image:
   { src: "midgard-app-banner.png", alt: "Midgard app banner" }
+images:
+  - { src: "midgard-iso.png", alt: "Midgard isometric factory view" }
+  - { src: "midgard-vision.png", alt: "Midgard vision artwork" }
 technos:
   [
     "SvelteKit",

--- a/src/content/portfolio/en/ponziland.md
+++ b/src/content/portfolio/en/ponziland.md
@@ -4,6 +4,8 @@ title: "PonziLand"
 snippet: "Fully onchain, token-agnostic DeFi metagame built on Starknet. A multi-language project with SvelteKit frontend, Cairo smart contracts using Dojo framework, and Rust-based indexer services"
 image:
   { src: "ponziland-display-full.png", alt: "PonziLand showcase" }
+images:
+  - { src: "ponziland-merch.png", alt: "PonziLand merch" }
 technos: ["Svelte", "TypeScript", "Cairo", "Dojo", "Rust", "Starknet", "PostgreSQL"]
 startDate: "2024-06-01 08:00"
 endDate: "2099-02-01 00:00"

--- a/src/content/portfolio/fr/je-intervenants.md
+++ b/src/content/portfolio/fr/je-intervenants.md
@@ -4,6 +4,9 @@ title: "JE Intervenants"
 snippet: "Plateforme pour Junior ISEP qui connecte alumni et experts du milieu professionnel aux équipes projet étudiantes via un annuaire d'experts navigable."
 image:
   { src: "je-intervenants-banner.png", alt: "Bannière de la plateforme JE Intervenants" }
+images:
+  - { src: "je-intervenants-design-thinking.png", alt: "Atelier de design thinking" }
+  - { src: "je-intervenants-notion-crm.png", alt: "CRM Notion des intervenants" }
 technos: ["Design Thinking", "UX Research", "Product Design", "Scrum", "Figma", "Notion", "CI/CD"]
 startDate: "2024-01-01 00:00"
 demo: "https://je-intervenants.juniorisep.com/"

--- a/src/content/portfolio/fr/midgard.md
+++ b/src/content/portfolio/fr/midgard.md
@@ -4,6 +4,9 @@ title: "Midgard"
 snippet: "Marchés compétitifs basés sur le score, sur Starknet. Les Factory Owners stakent sur des scores de jeu, les Challengers paient pour les battre, les Vault Investors apportent du capital. Construit par RuneLabs."
 image:
   { src: "midgard-app-banner.png", alt: "Bannière de l'app Midgard" }
+images:
+  - { src: "midgard-iso.png", alt: "Vue isométrique d'une factory Midgard" }
+  - { src: "midgard-vision.png", alt: "Artwork de la vision Midgard" }
 technos:
   [
     "SvelteKit",

--- a/src/content/portfolio/fr/ponziland.md
+++ b/src/content/portfolio/fr/ponziland.md
@@ -4,6 +4,8 @@ title: "PonziLand"
 snippet: "Métagame DeFi 100% onchain et token-agnostic, construit sur Starknet. Projet multi-langage avec frontend SvelteKit, smart contracts Cairo via Dojo et services d'indexation en Rust."
 image:
   { src: "ponziland-display-full.png", alt: "Aperçu PonziLand" }
+images:
+  - { src: "ponziland-merch.png", alt: "Merch PonziLand" }
 technos: ["Svelte", "TypeScript", "Cairo", "Dojo", "Rust", "Starknet", "PostgreSQL"]
 startDate: "2024-06-01 08:00"
 endDate: "2099-02-01 00:00"


### PR DESCRIPTION
## Summary

Project cards on the home page can now show up to **3 images**: the main image plus up to 2 secondary images that float slowly behind it.

- **Schema** (`src/content.config.ts`): new optional `images` frontmatter field on portfolio entries — array of `{ src, alt }`, max 2 entries, defaults to `[]`.
- **Rendering** (`src/components/projects.astro`): secondary images are absolutely positioned behind the main image (offset corners, slight rotation) with a slow `floatY` keyframe animation (8s / 11s, alternating). Offsets mirror on odd rows so floats peek outward from the image column.
- Floats are hidden below `md` to avoid clutter on mobile, and the animation is disabled under `prefers-reduced-motion`.
- Secondary images use Astro `<Image>` with smaller widths (300/500/700) and lazy loading; gif/unresolved sources fall back to a plain `<img>`.

Populated secondary images (EN + FR) for:
- **Midgard**: `midgard-iso.png`, `midgard-vision.png`
- **PonziLand**: `ponziland-merch.png`
- **JE Intervenants**: `je-intervenants-design-thinking.png`, `je-intervenants-notion-crm.png`

## Test plan

- [x] `pnpm build` passes (45 pages)
- [x] Built `index.html` contains 3× `float-img-1` and 2× `float-img-2` nodes with the `floatY` keyframes
- [ ] Visual check on desktop + verify floats hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)