### PR TITLE
Hide At a glance section, keep HTML for agents

### DIFF
--- a/src/components/at-a-glance.astro
+++ b/src/components/at-a-glance.astro
@@ -18,20 +18,18 @@ const facts = [
 ---
 
 <section
-  class="mb-16 rounded-lg border border-slate-200 bg-slate-50/80 px-6 py-5"
+  hidden
+  aria-hidden="true"
+  data-agent-context="at-a-glance"
   aria-labelledby="at-a-glance-heading"
 >
-  <h2 id="at-a-glance-heading" class="text-lg font-bold mb-4">
-    {t("glance.title")}
-  </h2>
-  <dl class="grid gap-3 sm:grid-cols-2">
+  <h2 id="at-a-glance-heading">{t("glance.title")}</h2>
+  <dl>
     {
       facts.map(({ label, value }) => (
         <div>
-          <dt class="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            {label}
-          </dt>
-          <dd class="font-inter text-slate-800 mt-0.5">{value}</dd>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
         </div>
       ))
     }


### PR DESCRIPTION
## Summary
Hides the homepage "At a glance" card from visitors while keeping the structured Who/What/Now/Where/Contact summary in the page HTML for LLM crawlers and agents. The section uses the `hidden` attribute and `data-agent-context="at-a-glance"` so it stays out of the visual layout and accessibility tree but remains machine-readable alongside existing `llms.txt` and JSON-LD.

## Test plan
- [ ] Load `/` and `/fr/` and confirm the At a glance card no longer appears
- [ ] View page source and confirm the hidden section with glance facts is still present
- [ ] Verify screen readers skip the section (`aria-hidden="true"`)

Made with [Cursor](https://cursor.com)